### PR TITLE
Add general project description to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 Rootstrap Guides
 ======
 
+This repository contains several guidelines that document processes and standards followed by our entire organization. We hope they may serve as a recommendation to anyone interested in following our quality standards.  
+Guidelines are based on our own experiences and other companies' best practices.  
+The guidelines exploit Git's advantages with regards to collaborative work, encouraging all of our developers to get actively involved with them.
+
+### General
+
 * [Code review](./code-review)
 * [Git Workflow](./git)
 * [Git commits](./git/commits.md)
 * [Open Source](./open_source.md)
 
-## Languages
+### Languages
 
 * [Ruby](./ruby)
 * [Swift](./swift)
 * [Javascript](https://github.com/airbnb/javascript)
 * [CSS](./css.md)
 
-## Frameworks/Libraries
+### Frameworks/Libraries
 
 * [Ruby on Rails](./ruby/rails.md)
 * [Angular 1](https://github.com/johnpapa/angular-styleguide/blob/master/a1)


### PR DESCRIPTION
### Description
This PR is to add an introductory description of the project. Additionally, other guides that were not included in Language and Frameworks are now wrapped into a new General section.

Preview: https://github.com/rootstrap/guides/tree/enhancement/add_guides_description